### PR TITLE
Re-enable mccabe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ select = [
     # isort
     "I",
     # mccabe
-    # "C",
+    "C",
     # pycodestyle
     "E",
     "W",
@@ -36,6 +36,10 @@ ignore = [
     # TODO: Remove E501 by fixing docstrings
     "E501"
 ]
+
+[tool.ruff.lint.mccabe]
+# Double the max complexity
+max-complexity = 20
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402"]


### PR DESCRIPTION
- McCabe was already enabled and adhered to in the code before the switch to Ruff
- Re-enable this by changing the appropriate settings