### PR TITLE
Apply all ruff linters, with minimal exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,19 +22,11 @@ strict = true
 
 [tool.ruff.lint]
 select = [
-    # isort
-    "I",
-    # mccabe
-    "C",
-    # pycodestyle
-    "E",
-    "W",
-    # pydocstyle
-    "D",
-    # Pyflakes
-    "F",
+    "ALL",
 ]
 ignore = [
+    # Missing trailing comma (not recommended with formatter)
+    "COM812",
     # Missing docstring in magic method
     "D105",
     # Taken care of by formatting. Ignore for docstrings

--- a/src/ff_toolbox/model/core/draft.py
+++ b/src/ff_toolbox/model/core/draft.py
@@ -40,18 +40,19 @@ class Draft:
             RuntimeError: Player unavailable to pick, can't add another pick
         """
         if player not in self._undrafted:
-            raise RuntimeError(f"Player {player} not available to pick")
+            err = f"Player {player} not available to pick"
+            raise RuntimeError(err)
         if (not pick_num) or (pick_num - 1 == len(self._picks)):
             # If adding next pick, remove player from undrafted and add to next pick's team
             if len(self._picks) == len(self._order) * self._rounds:
-                raise RuntimeError("Can't add another pick. Draft already complete.")
+                err = "Can't add another pick. Draft already complete."
+                raise RuntimeError(err)
             self.pick_num_to_team(len(self._picks) + 1).roster.add_player(player)
             self._undrafted.remove(player)
             self._picks.append(player)
         elif (len(self._picks) < pick_num - 1) or (pick_num <= 0):
-            raise ValueError(
-                f"Pick number {pick_num} is out of range. The next pick is pick {len(self._picks) + 1}"
-            )
+            err = f"Pick number {pick_num} is out of range. The next pick is pick {len(self._picks) + 1}"
+            raise ValueError(err)
         else:
             # If changing pick, remove player from team and add to player pool.
             self.pick_num_to_team(pick_num).roster.remove_player(player)
@@ -68,7 +69,7 @@ class Draft:
             num_picks (int | None): Number of picks to delete from end of draft. None to delete all picks.
         """
         new_num_picks = num_picks if num_picks else len(self._picks)
-        for pick in range(new_num_picks):
+        for _ in range(new_num_picks):
             self.pick_num_to_team(len(self._picks)).roster.remove_player(
                 self._picks[-1]
             )
@@ -89,10 +90,11 @@ class Draft:
         """
         num_picks: int = len(self._order) * self._rounds
         if pick_num <= 0 or pick_num > num_picks:
-            raise ValueError(f"Pick number {pick_num} for draft with {num_picks} picks")
+            err = f"Pick number {pick_num} for draft with {num_picks} picks"
+            raise ValueError(err)
         team_num = (pick_num - 1) % len(self._order)
-        round = (pick_num - 1) // len(self._order) + 1
-        if round % 2 == 0:
+        draft_round = (pick_num - 1) // len(self._order) + 1
+        if draft_round % 2 == 0:
             team_num = len(self._order) - team_num - 1
         return self._order[team_num]
 

--- a/src/ff_toolbox/model/core/phys_representations.py
+++ b/src/ff_toolbox/model/core/phys_representations.py
@@ -55,32 +55,36 @@ class Player:
         Returns:
             bool: True if player is eligible for roster spot, False if not
         """
+        ret = False
         match roster_spot:
             case RosterSpot.QB:
-                return self.position == Position.QB
+                ret = self.position == Position.QB
             case RosterSpot.RB:
-                return self.position == Position.RB
+                ret = self.position == Position.RB
             case RosterSpot.WR:
-                return self.position == Position.WR
+                ret = self.position == Position.WR
             case RosterSpot.TE:
-                return self.position == Position.TE
+                ret = self.position == Position.TE
             case RosterSpot.DST:
-                return self.position == Position.DST
+                ret = self.position == Position.DST
             case RosterSpot.K:
-                return self.position == Position.K
+                ret = self.position == Position.K
             case RosterSpot.FLEX:
-                return self.position in [Position.RB, Position.WR, Position.TE]
+                ret = self.position in [Position.RB, Position.WR, Position.TE]
             case RosterSpot.QBFLEX:
-                return self.position in [
+                ret = self.position in [
                     Position.QB,
                     Position.RB,
                     Position.WR,
                     Position.TE,
                 ]
             case RosterSpot.BENCH:
-                return True
+                ret = True
             case RosterSpot.IR:
-                return self.ir_eligible
+                ret = self.ir_eligible
+            case _:
+                ret = False
+        return ret
 
     def __str__(self) -> str:
         return f"{self.name} {self.team} ({self.position.name})"
@@ -116,7 +120,8 @@ class Roster:
                 added = True
                 break
         if not added:
-            raise RuntimeError(f"No space on roster for player {player}")
+            err = f"No space on roster for player {player}"
+            raise RuntimeError(err)
 
     def remove_player(self, player: Player) -> None:
         """Remove given player from roster if on roster.
@@ -148,9 +153,8 @@ class Roster:
                 p2_roster_spot = roster_spot
         # Swap spot on roster
         if not (p1_roster_spot and p2_roster_spot):
-            raise RuntimeError(
-                f"Couldn't swap players {player1} and {player2} on roster"
-            )
+            err = f"Couldn't swap players {player1} and {player2} on roster"
+            raise RuntimeError(err)
         self._players[p1_roster_spot].remove(player1)
         self._players[p1_roster_spot].append(player2)
         self._players[p2_roster_spot].remove(player2)
@@ -165,22 +169,21 @@ class Roster:
         """
         # Verify there's space at roster spot for player and player is eligible to play there
         if len(self._players[roster_spot]) >= self._settings[roster_spot]:
-            raise RuntimeError(
-                f"No open roster spot at {roster_spot.name} to move player to"
-            )
+            err = f"No open roster spot at {roster_spot.name} to move player to"
+            raise RuntimeError(err)
         if not player.is_roster_eligible(roster_spot):
-            raise RuntimeError(
-                f"Player {player} isn't eligible to be placed at {roster_spot.name}"
-            )
+            err = f"Player {player} isn't eligible to be placed at {roster_spot.name}"
+            raise RuntimeError(err)
         # Verify player is on roster and remove them from roster temporarily
         player_on_roster: bool = False
-        for roster_spot, players in self._players.items():
+        for roster_spot_, players in self._players.items():
             if player in players:
-                self._players[roster_spot].remove(player)
+                self._players[roster_spot_].remove(player)
                 player_on_roster = True
                 break
         if not player_on_roster:
-            raise RuntimeError(f"Player {player} does not already exist on roster")
+            err = f"Player {player} does not already exist on roster"
+            raise RuntimeError(err)
         # Add player back to new roster spot
         self._players[roster_spot].append(player)
 

--- a/src/ff_toolbox/model/pick_suggestors/simple_pick_suggestor.py
+++ b/src/ff_toolbox/model/pick_suggestors/simple_pick_suggestor.py
@@ -22,7 +22,6 @@ class SimplePickSuggestor(AbstractPickSuggestor):
         Returns:
             dict[Player, float]: Dictionary of {undrafted_player, relative_suggestion_strength}, sorted by suggestion strength
         """
-        #
         player_rankings = self._my_pick_analyzer.eval_players(
             avail_players=draft_status.undrafted,
             my_ranking=self._pick_predictor.my_rankings,


### PR DESCRIPTION
- Use "ALL" for ruff lint selection
- Only disable COM812, since it's recommended
- More rules can be disabled in the future as development continues, but no more were required for the existing body of code